### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@
 
 For more information, help, to report issues etc. see [slog-rs][slog-rs].
 
-[slog-rs]: //github.com/slog-rs/slog
+[slog-rs]: https://github.com/slog-rs/slog


### PR DESCRIPTION
Crates.io does not understand the currently used link format. Update the links so that they should render correctly on cartes.io.